### PR TITLE
Delete article with favorite

### DIFF
--- a/priv/repo/migrations/20171225141624_add_cascade_delete_to_favorites.exs
+++ b/priv/repo/migrations/20171225141624_add_cascade_delete_to_favorites.exs
@@ -1,0 +1,17 @@
+defmodule RealWorld.Repo.Migrations.AddCascadeDeleteToFavorites do
+  use Ecto.Migration
+
+  def up do
+    execute "ALTER TABLE favorites DROP CONSTRAINT favorites_article_id_fkey"
+    alter table(:favorites) do
+      modify :article_id, references(:articles, on_delete: :delete_all)
+    end
+  end
+
+  def down do
+    execute "ALTER TABLE favorites DROP CONSTRAINT favorites_article_id_fkey"
+    alter table(:favorites) do
+      modify :article_id, references(:articles)
+    end
+  end
+end

--- a/test/real_world_web/controllers/article_controller_test.exs
+++ b/test/real_world_web/controllers/article_controller_test.exs
@@ -141,4 +141,13 @@ defmodule RealWorldWeb.ArticleControllerTest do
       get conn, article_path(conn, :show, article)
     end
   end
+
+  test "deletes chosen article previously favorited by an user",
+                                                      %{conn: conn, jwt: jwt, article: article, user: user} do
+    insert(:favorite, user: user, article: article)
+
+    conn = conn |> put_req_header("authorization", "Token #{jwt}")
+    conn = delete conn, article_path(conn, :delete, article.slug)
+    assert response(conn, 204)
+  end
 end

--- a/test/real_world_web/controllers/article_controller_test.exs
+++ b/test/real_world_web/controllers/article_controller_test.exs
@@ -100,7 +100,7 @@ defmodule RealWorldWeb.ArticleControllerTest do
     }
   end
 
-  test "deletes the given article favorited by the user", %{conn: conn, jwt: jwt, article: article, user: user} do
+  test "unfavorites an article favorited by the user", %{conn: conn, jwt: jwt, article: article, user: user} do
     insert(:favorite, user: user, article: article)
 
     conn = conn |> put_req_header("authorization", "Token #{jwt}")


### PR DESCRIPTION
This pull request tries to resolve issue #6.

### Changes

  * Creates migration to add an ON DELETE constraint to `favorites` table on `article_id` field;
  * Change the description of test for unfavorite an article in order to avoid a possible misunderstanding in the future.

### Screenshots

#### Migration output

<img width="697" alt="favorites migrate" src="https://user-images.githubusercontent.com/438257/34340922-8bd96bbe-e984-11e7-8d39-abd974fbbd2b.png">

#### Database state after migration

<img width="752" alt="favorites after migrate" src="https://user-images.githubusercontent.com/438257/34340937-b7605e46-e984-11e7-9a73-f1706d7a60de.png">

#### Rollback output

<img width="750" alt="favorites rollback" src="https://user-images.githubusercontent.com/438257/34340938-bdbc37ec-e984-11e7-8681-ab7aeda52995.png">

#### Database state after rollback

<img width="645" alt="favorites after rollback" src="https://user-images.githubusercontent.com/438257/34340939-c1eb3ea8-e984-11e7-9c2b-d83bcf16821c.png">
