### PR TITLE
Bugfix: user's password not hashed on update

### DIFF
--- a/lib/real_world/accounts/auth.ex
+++ b/lib/real_world/accounts/auth.ex
@@ -32,7 +32,7 @@ defmodule RealWorld.Accounts.Auth do
     end
   end
 
-  defp hash_password(changeset) do
+  def hash_password(changeset) do
     case changeset do
       %Ecto.Changeset{valid?: true, changes: %{password: pass}} ->
         put_change(changeset, :password, Encryption.password_hashing(pass))

--- a/lib/real_world/accounts/users.ex
+++ b/lib/real_world/accounts/users.ex
@@ -13,6 +13,7 @@ defmodule RealWorld.Accounts.Users do
   def update_user(user, attrs) do
     user
     |> User.changeset(attrs)
+    |> RealWorld.Accounts.Auth.hash_password()
     |> Repo.update()
   end
 

--- a/test/real_world/auth_test.exs
+++ b/test/real_world/auth_test.exs
@@ -1,0 +1,23 @@
+defmodule RealWorld.Accounts.AuthTest do
+  @moduledoc false
+  use RealWorld.DataCase
+
+  alias RealWorld.Accounts.Auth
+
+  @user_create_attrs %{
+    email: "some email",
+    password: "some password",
+    username: "some username",
+    bio: "some bio",
+    image: "some image"
+  }
+
+  test "register/1 creates a user" do
+    Auth.register(@user_create_attrs)
+  end
+
+  test "register/1 returns error if email is used already" do
+    Auth.register(@user_create_attrs)
+    assert {:error, _} = Auth.register(@user_create_attrs)
+  end
+end

--- a/test/real_world/users_test.exs
+++ b/test/real_world/users_test.exs
@@ -1,8 +1,9 @@
-defmodule RealWorld.Accounts.AuthTest do
-  @moduledoc false
+defmodule RealWorld.Accounts.UsersTest do
+  @moduledoc nil
+
   use RealWorld.DataCase
 
-  alias RealWorld.Accounts.Auth
+  alias RealWorld.Accounts.Users
 
   @user_create_attrs %{
     email: "some email",
@@ -12,12 +13,15 @@ defmodule RealWorld.Accounts.AuthTest do
     image: "some image"
   }
 
-  test "register/1 creates a user" do
-    Auth.register(@user_create_attrs)
-  end
+  test "update_user/2 hashes the password if new one set" do
+    {:ok, user} = RealWorld.Accounts.Auth.register(@user_create_attrs)
 
-  test "register/1 returns error if email is used already" do
-    Auth.register(@user_create_attrs)
-    assert {:error, _} = Auth.register(@user_create_attrs)
+    new_password = "newPassword!123"
+
+    Users.update_user(user, %{password: new_password})
+
+    assert RealWorld.Accounts.Auth.find_user_and_check_password(%{
+             "user" => %{"email" => @user_create_attrs.email, "password" => new_password}
+           })
   end
 end


### PR DESCRIPTION
## Bug

On updating your password via settings page you can no longer login.

## Fix

Hash the password on update as is done with registering.

## Comments

I've added a test case to show this was failing.

The changes on the test files look a little messy, this is because before my change `RealWorld.Accounts.AuthTest` was at `test/real_world/users_test.exs`

